### PR TITLE
Chain resolvers to learn query

### DIFF
--- a/server/src/entity/Activity.ts
+++ b/server/src/entity/Activity.ts
@@ -1,11 +1,10 @@
 import { Field, ObjectType } from "type-graphql"
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Repository } from "typeorm"
+import { Column, Entity,  ManyToOne, OneToMany, PrimaryGeneratedColumn, Repository } from "typeorm"
 import type { IActivity } from "../@types/entity/IActivity";
 import { AppDataSource } from "../data-source.js";
 import type { Relation } from "typeorm";
-import LearningFile from "./LearningFile.js";
-import Technique from "./Technique.js";
 import Event from "./Event.js";
+import LearningFile from "./LearningFile.js";
 
 @ObjectType("ActivityType")
 @Entity({ name: "Activity" })
@@ -27,6 +26,12 @@ export default class Activity implements IActivity {
   @Field()
   @Column()
   endTime: Date;
+
+  @ManyToOne(() => Event, (event) => event.id)
+  event: Relation<Event>
+
+  @OneToMany(() => LearningFile, (learningFile) => learningFile.id)
+  learningFiles: [LearningFile]
 
   constructor(params?: IActivity) {
     Object.assign(this, params);

--- a/server/src/entity/Event.ts
+++ b/server/src/entity/Event.ts
@@ -1,5 +1,5 @@
 import { Field, ID, ObjectType } from "type-graphql";
-import { Column, Entity, JoinColumn, JoinTable, ManyToMany, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
 import type { Relation } from "typeorm";
 import type { EventTypeEnum, IEvent } from "../@types/entity/IEvent";
 import { AppDataSource } from "../data-source.js";
@@ -70,8 +70,12 @@ export default class Event implements IEvent{
     })
   }
 
-  async readEvent(): Promise<Event | null> { 
-    return await this.repository.findOneBy({id: this.id});
+  async readEvent(): Promise<Array<Event> | null> { 
+    return await this.repository.find({
+      relations: {
+        learner: true
+      }
+    });
   }
 
 }

--- a/server/src/entity/Learner.ts
+++ b/server/src/entity/Learner.ts
@@ -44,13 +44,13 @@ class Learner implements ILearner {
     if (this.password) {
       this.password = createHmac('sha256', JWT_CONFIG.secret).update(this.password).digest('hex')
     }
-  }
+  } 
 
   @OneToMany(() => Event, (event) => event.id)
-  events: Event[]
-
+  events: [Event]
+  
   @OneToMany(() => Technique, (technique) => technique.id)
-  techniques: Technique[]
+  techniques: [Technique]
 
   constructor(params?: ILearner) {
     Object.assign(this, params);

--- a/server/src/entity/LearningFile.ts
+++ b/server/src/entity/LearningFile.ts
@@ -24,10 +24,10 @@ export default class LearningFile implements ILearningFile {
   format: string
 
   @ManyToOne(() => Event, (event) => event.id)
-  events: Relation<Event>
+  event: Relation<Event>
 
   @ManyToOne(() => Activity, (activity) => activity.id)
-  activities: Relation<Activity>
+  activity: Relation<Activity>
 
   constructor(params?: ILearningFile) {
     Object.assign(this, params);

--- a/server/src/resolver/activity/ActivityResolver.ts
+++ b/server/src/resolver/activity/ActivityResolver.ts
@@ -1,51 +1,53 @@
 import { GraphQLError } from "graphql";
-import { Arg, Mutation, Query, Resolver } from "type-graphql";
+import { Arg, FieldResolver, Mutation, Resolver, Root } from "type-graphql";
 import Activity from "../../entity/Activity.js";
+import Learner from "../../entity/Learner.js";
 import { ActivityInput, ActivityUpdateInput } from "./ActivityInput.js";
+import Event from "../../entity/Event.js";
 
-@Resolver(Activity)
+@Resolver(() => Event)
 export class ActivityResolver {
-
-    // Given an id, returns the Activity object
-    @Query(() => Activity, {nullable:true})
-    async activity(@Arg("id") id:number){
+    //TODO: Documentaton
+    //NOTE: Getting the activities from the Learner
+    @FieldResolver(() => Activity, { nullable: true })
+    async activity(@Root() event: Event) {
         let activity = new Activity();
-        activity.id = id;
+        activity.event = event;
         return await activity.readActivity();
     }
 
     // Given Activity data, CREATES and returns Activity object
-    @Mutation(()=>Activity,{nullable:true})
-    async createActivity(@Arg("createInput") createInput:ActivityInput){
+    @Mutation(() => Activity, { nullable: true })
+    async createActivity(@Arg("createInput") createInput: ActivityInput) {
         let activity: Activity | null = new Activity(createInput);
         await activity.createActivity();
         return await activity.readActivity();
     }
 
     // Given Activity data and ID, UPDATES and returns Activity object
-    @Mutation(() => Activity||null)
-    async updateActivity(@Arg("updateInput") updateInput: ActivityUpdateInput){
+    @Mutation(() => Activity || null)
+    async updateActivity(@Arg("updateInput") updateInput: ActivityUpdateInput) {
         const ACTUAL = new Activity(updateInput)
         const OLD = new Activity();
         OLD.id = updateInput.id;
 
-        if(!await OLD.readActivity()){
-            throw new GraphQLError("The activity does not exist."); 
-        }else{
+        if (!await OLD.readActivity()) {
+            throw new GraphQLError("The activity does not exist.");
+        } else {
             await ACTUAL.updateActivity();
-            return ACTUAL.readActivity();   
+            return ACTUAL.readActivity();
         }
     }
 
     // Given an ID, DELETE an Activity
-    @Mutation(()=> String)
-    async deleteActivity(@Arg("id")id:number){
+    @Mutation(() => String)
+    async deleteActivity(@Arg("id") id: number) {
         let activity: Activity | null = new Activity();
         activity.id = id
         const TEMP = await activity.readActivity();
-        if(!TEMP){
-            throw new GraphQLError("The activity does not exist."); 
-        }else{
+        if (!TEMP) {
+            throw new GraphQLError("The activity does not exist.");
+        } else {
             await activity.deleteActivity();
             return `Activity ${TEMP.title} was deleted`;
         }

--- a/server/src/resolver/event/EventResolver.ts
+++ b/server/src/resolver/event/EventResolver.ts
@@ -1,25 +1,38 @@
 import { GraphQLError } from "graphql";
-import { Arg, Mutation, Query, Resolver } from "type-graphql";
+import { Arg, FieldResolver, Mutation, Query, Resolver, Root } from "type-graphql";
 import Event from "../../entity/Event.js"
 import { EventInput, EventUpdateInput } from "./EventInput.js";
+import { CurrentUser } from "../../context.js";
+import Learner from "../../entity/Learner.js";
 
-@Resolver(Event)
+@Resolver(() => Learner)
 export class EventResolver {
 
     // Given an id, returns the Event object
-    @Query(() => Event, { nullable: true })
-    async event(@Arg("id") id: number) {
+    @FieldResolver(() => [Event], { nullable: true })
+    async events(
+        @Root() learner: Learner
+    ) { 
         let event = new Event();
-        event.id = id;
+        console.log(learner.id);
+        event.learner = learner; 
         return await event.readEvent();
     }
 
     // Given Event data, CREATES and returns Event object
     @Mutation(() => Event, { nullable: true })
-    async createEvent(@Arg("createInput") createInput: EventInput) {
+    async createEvent(
+        @Arg("createInput") createInput: EventInput,
+        @CurrentUser() currentUser: number
+    ) {
+        let learner = new Learner();
+        learner.id = currentUser;
+        
         let event: Event | null = new Event(createInput);
-        await event.createEvent();
-        return await event.readEvent();
+        event.learner = learner;
+        await event.createEvent(); 
+
+        return event;
     }
 
     // Given Event data and ID, UPDATES and returns Event object
@@ -40,7 +53,7 @@ export class EventResolver {
     // Given an ID, DELETE an Event
     @Mutation(() => String)
     async deleteEvent(@Arg("id") id: number) {
-        let event: Event | null = new Event();
+        /*let event: Event | null = new Event();
         event.id = id
         const TEMP = await event.readEvent();
         if (!TEMP) {
@@ -48,7 +61,7 @@ export class EventResolver {
         } else {
             await event.deleteEvent();
             return `Event ${TEMP.title} was deleted`;
-        }
+        } */
     }
 
 }

--- a/server/src/resolver/learner/LearnerInput.ts
+++ b/server/src/resolver/learner/LearnerInput.ts
@@ -26,7 +26,19 @@ class LearnerLogInInput implements ILearner{
 
 }
 
+@InputType()
+class LearnerUpdateInput implements ILearner{
+  @Field()
+  fullname: string
+  @Field()
+  password: string
+
+  username:string
+  email:string
+}
+
 export {
   LearnerSignUpInput,
-  LearnerLogInInput
+  LearnerLogInInput,
+  LearnerUpdateInput
 }

--- a/server/src/resolver/learningFile/LearningFileResolver.ts
+++ b/server/src/resolver/learningFile/LearningFileResolver.ts
@@ -1,55 +1,57 @@
 import { GraphQLError } from "graphql";
-import { Arg, Mutation, Query, Resolver } from "type-graphql";
+import { Arg, FieldResolver, Mutation, Query, Resolver, Root } from "type-graphql";
 import LearningFile from "../../entity/LearningFile.js";
 import { LearningFileInput, LearningFileUpdateInput } from "./LearningFileInput.js";
+import Event from "../../entity/Event.js";
+import Activity from "../../entity/Activity.js"
 
-@Resolver(LearningFile)
-export class LearningFileResolver{
+@Resolver(() => Activity)
+export class LearningFileResolver {
 
-    // Given an id, returns the LearningFile object
-    @Query(() => LearningFile, { nullable: true })
-    async learningFile(@Arg("id") id: number) {
-        let learningFile = new LearningFile();
-        learningFile.id = id;
-        return await learningFile.readLearningFile();
+  //TODO: Implements learning files to Events.
+  @FieldResolver(() => LearningFile, { nullable: true })
+  async learningFile(@Root() activity: Activity) {
+    let learningFile = new LearningFile();
+    learningFile.activity = activity;
+    return await learningFile.readLearningFile();
+  }
+
+  // Given LearningFile data, CREATES and returns LearningFile object
+  @Mutation(() => LearningFile, { nullable: true })
+  async createLearningFile(@Arg("createInput") createInput: LearningFileInput) {
+    let learningFile: LearningFile | null = new LearningFile(createInput);
+    await learningFile.createLearningFile();
+    return await learningFile.readLearningFile();
+  }
+
+  // Given LearningFile data and ID, UPDATES and returns LearningFile object
+  @Mutation(() => LearningFile || null)
+  async updateLearningFile(@Arg("updateInput") updateInput: LearningFileUpdateInput) {
+    const ACTUAL = new LearningFile(updateInput)
+    const OLD = new LearningFile();
+    OLD.id = updateInput.id;
+
+    if (!await OLD.readLearningFile()) {
+      throw new GraphQLError("The Learning File does not exist.");
+    } else {
+      await ACTUAL.updateLearningFile();
+      return ACTUAL.readLearningFile();
     }
+  }
 
-    // Given LearningFile data, CREATES and returns LearningFile object
-    @Mutation(() => LearningFile, { nullable: true })
-    async createLearningFile(@Arg("createInput") createInput: LearningFileInput) {
-        let learningFile: LearningFile | null = new LearningFile(createInput);
-        await learningFile.createLearningFile();
-        return await learningFile.readLearningFile();
+
+  // Given an ID, DELETE a LearningFile
+  @Mutation(() => String)
+  async deleteLearningFile(@Arg("id") id: number) {
+    let learningFile: LearningFile | null = new LearningFile();
+    learningFile.id = id
+    const TEMP = await learningFile.readLearningFile();
+    if (!TEMP) {
+      throw new GraphQLError("The Learning File does not exist.");
+    } else {
+      await learningFile.deleteLearningFile();
+      return `Learning File ${TEMP.fileName} was deleted`;
     }
-
-    // Given LearningFile data and ID, UPDATES and returns LearningFile object
-    @Mutation(() => LearningFile||null)
-    async updateLearningFile(@Arg("updateInput") updateInput: LearningFileUpdateInput){
-        const ACTUAL = new LearningFile(updateInput)
-        const OLD = new LearningFile();
-        OLD.id = updateInput.id;
-
-        if(!await OLD.readLearningFile()){
-            throw new GraphQLError("The Learning File does not exist."); 
-        }else{
-            await ACTUAL.updateLearningFile();
-            return ACTUAL.readLearningFile();   
-        }
-    }
-
-
-    // Given an ID, DELETE a LearningFile
-    @Mutation(()=> String)
-    async deleteLearningFile(@Arg("id")id:number){
-        let learningFile: LearningFile | null = new LearningFile();
-        learningFile.id = id
-        const TEMP = await learningFile.readLearningFile();
-        if(!TEMP){
-            throw new GraphQLError("The Learning File does not exist."); 
-        }else{
-            await learningFile.deleteLearningFile();
-            return `Learning File ${TEMP.fileName} was deleted`;
-        }
-    }
+  }
 
 }

--- a/server/src/resolver/technique/TechniqueResolver.ts
+++ b/server/src/resolver/technique/TechniqueResolver.ts
@@ -1,16 +1,18 @@
 import { GraphQLError } from "graphql";
-import { Arg, Mutation, Query, Resolver } from "type-graphql";
+import { Arg, FieldResolver, Mutation, Resolver, Root } from "type-graphql";
+import Learner from "../../entity/Learner.js";
 import Technique from "../../entity/Technique.js";
 import { TechniqueInput, TechniqueUpdateInput } from "./TechniqueInput.js";
 
-@Resolver(Technique)
+@Resolver(() => Learner)
 export class TechniqueResolver {
 
-    // Given an id, returns the Technique object
-    @Query(() => Technique, { nullable: true })
-    async technique(@Arg("id") id: number) {
+    //TODO: Documentation
+    //NOTE: Get techniques from the current user
+    @FieldResolver(() => Technique, { nullable: true })
+    async technique(@Root() learner: Learner) {
         let technique = new Technique();
-        technique.id = id;
+        technique.learner = learner;
         return await technique.readTechnique();
     }
 


### PR DESCRIPTION
Added chaining resolvers from learners to learning files, improving the structure and organization of our codebase. However, during testing, we discovered a problem with the same field resolvers for `events` and `activities`. Specifically, both contain learning files as a field, which is causing issues with our query. We will need to investigate this further and determine the best approach to resolve this conflict. 

The TypeGrahQL community problem https://github.com/MichalLytek/type-graphql/issues/193.

Example
```graphql
query learner {
  learner {
    email
    events {
      id
      title
      endDate
      activity {
        id
        endTime
        learningFile {
          id
          format
        }
      }
    }
  }
}

```